### PR TITLE
Use best DisplayEnv at symbol position to format types

### DIFF
--- a/src/fsharp/vs/service.fs
+++ b/src/fsharp/vs/service.fs
@@ -1635,6 +1635,9 @@ type TypeCheckInfo
     member x.CcuSig = ccuSig
     member x.ThisCcu = thisCcu
 
+    /// Find the most precise display context for the given line and column.
+    member x.GetBestDisplayEnvForPos cursorPos  = GetBestEnvForPos cursorPos
+
 module internal Parser = 
 
         // We'll need number of lines for adjusting error messages at EOF
@@ -2278,6 +2281,12 @@ type FSharpCheckFileResults(errors: FSharpErrorInfo[], scopeOptX: TypeCheckInfo 
         reactorOp "IsRelativeNameResolvable" true (fun ctok scope -> 
             DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent  ctok
             scope.IsRelativeNameResolvable(pos, plid, item))
+
+    member info.GetDisplayEnvForPos(pos: pos) : Async<DisplayEnv option> = 
+        reactorOp "GetDisplayContextAtPos" None (fun ctok scope -> 
+            DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent ctok
+            let (nenv, _), _ = scope.GetBestDisplayEnvForPos(pos)
+            Some nenv.DisplayEnv)
     
 //----------------------------------------------------------------------------
 // BackgroundCompiler

--- a/src/fsharp/vs/service.fsi
+++ b/src/fsharp/vs/service.fsi
@@ -312,6 +312,10 @@ type internal FSharpCheckFileResults =
 
     /// Determines if a long ident is resolvable at a specific point.
     member IsRelativeNameResolvable: cursorPos : pos * plid : string list * item: Item -> Async<bool>
+    
+    /// Find the most precise display environment for the given line and column.
+    member GetDisplayEnvForPos : pos : pos -> Async<DisplayEnv option>
+
 /// A handle to the results of CheckFileInProject.
 [<Sealed>]
 type internal FSharpCheckProjectResults =

--- a/vsintegration/src/FSharp.Editor/CodeLens/CodeLens.fs
+++ b/vsintegration/src/FSharp.Editor/CodeLens/CodeLens.fs
@@ -25,7 +25,7 @@ open Microsoft.CodeAnalysis.Editor.Shared.Utilities
 open Microsoft.CodeAnalysis.Classification
 open Internal.Utilities.StructuredFormat
 open Microsoft.VisualStudio.Text.Tagging
-open Microsoft.VisualStudio.Text.Editor
+open System.Collections.Concurrent
 
 type internal CodeLensAdornment
     (
@@ -38,7 +38,7 @@ type internal CodeLensAdornment
     ) as self =
     
     let formatMap = lazy typeMap.Value.ClassificationFormatMapService.GetClassificationFormatMap "tooltip"
-    let codeLensLines = Dictionary()
+    let codeLensLines = ConcurrentDictionary()
 
     do assert (documentId <> null)
 
@@ -150,7 +150,7 @@ type internal CodeLensAdornment
         // Non expensive computations which have to be done immediate
         for line in e.NewOrReformattedLines do
             let lineNumber = view.TextSnapshot.GetLineNumberFromPosition(line.Start.Position)
-            codeLensLines.Remove(lineNumber) |> ignore //All changed lines are supposed to be now No-CodeLens-Lines (Reset)
+            codeLensLines.TryRemove(lineNumber) |> ignore //All changed lines are supposed to be now No-CodeLens-Lines (Reset)
 
         for line in view.TextViewLines.WpfTextViewLines do
             if line.VisibilityState = VisibilityState.Unattached then 

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -159,9 +159,9 @@ module private FSharpQuickInfo =
 
 [<ExportQuickInfoProvider(PredefinedQuickInfoProviderNames.Semantic, FSharpConstants.FSharpLanguageName)>]
 type internal FSharpQuickInfoProvider 
-    [<System.ComponentModel.Composition.ImportingConstructor>] 
+    [<ImportingConstructor>] 
     (
-        [<System.ComponentModel.Composition.Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider,
+        [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider,
         checkerProvider: FSharpCheckerProvider,
         projectInfoManager: ProjectInfoManager,
         gotoDefinitionService: FSharpGoToDefinitionService,

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -34,7 +34,7 @@ module private SessionHandling =
                   member __.AugmentQuickInfoSession(session,_,_) = currentSession <- Some session
                   member __.Dispose() = () }
 
-module private HyperlinkStyles =
+module internal HyperlinkStyles =
     // TODO: move this one time initialization to a more suitable spot
     do Application.ResourceAssembly <- typeof<Microsoft.VisualStudio.FSharp.UIResources.Strings>.Assembly
     let private styles = ResourceDictionary(Source = Uri("HyperlinkStyles.xaml", UriKind.Relative))


### PR DESCRIPTION
It show the shortest possible type names, like in Quick Info:

![image](https://cloud.githubusercontent.com/assets/873919/25448951/e09a0824-2ac2-11e7-9aff-c80b601fd1da.png)

(was: `System.DateTime`)