### PR TITLE
Bind only from XAML

### DIFF
--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -122,8 +122,4 @@ module internal OptionsUI =
     type internal CodeLensOptionPage() =
         inherit AbstractOptionPage<CodeLensOptions>()
         override this.CreateView() =
-            let view = CodeLensOptionControl()
-            bindCheckBox view.replaceWithLineLens "ReplaceWithLineLens"
-            bindCheckBox view.enableCodeLens "Enabled"
-            bindTextBox view.prefix "Prefix"
-            upcast view
+            upcast CodeLensOptionControl()

--- a/vsintegration/src/FSharp.Editor/Options/UIHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Options/UIHelpers.fs
@@ -65,9 +65,6 @@ module internal OptionsUIHelpers =
     let bindCheckBox (checkBox: CheckBox) (path: string) =
         checkBox.SetBinding(CheckBox.IsCheckedProperty, path) |> ignore
 
-    let bindTextBox (textBox: TextBox) (path: string) =
-        textBox.SetBinding(TextBox.TextProperty, path) |> ignore
-        
     // some helpers to create option views in code instead of XAML
     let ( *** ) (control : #IAddChild) (children: UIElement list) =
         children |> List.iter control.AddChild

--- a/vsintegration/src/FSharp.UIResources/CodeLensOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/CodeLensOptionControl.xaml
@@ -19,7 +19,7 @@
             <StackPanel>
                 <GroupBox Header="{x:Static local:Strings.CodeLens}">
                     <StackPanel>
-                        <CheckBox x:Name="enableCodeLens" IsChecked="{Binding CodeLensSwitch}"
+                        <CheckBox x:Name="enableCodeLens" IsChecked="{Binding Enabled}"
                       Content="{x:Static local:Strings.CodeLens_Switch}"/>
                         <CheckBox x:Name="replaceWithLineLens" IsChecked="{Binding ReplaceWithLineLens}"
                       Content="{x:Static local:Strings.CodeLens_Replace_LineLens}"/>
@@ -30,12 +30,9 @@
                             </Grid.ColumnDefinitions>
                             <Label Grid.Column="0" Content="{x:Static local:Strings.CodeLens_Prefix}"/>
                             <TextBox x:Name="prefix" Grid.Column="1" 
+                                Text="{Binding Prefix, UpdateSourceTrigger=PropertyChanged}"
                                 HorizontalContentAlignment="Right" 
                                 VerticalContentAlignment="Center" Margin="7,0,-116,0">
-                                <TextBox.Text>
-                                    <Binding UpdateSourceTrigger="PropertyChanged" Path="Prefix">
-                                    </Binding>
-                                </TextBox.Text>
                             </TextBox>
                         </Grid>
                     </StackPanel>


### PR DESCRIPTION
Fixes issue where "prefix" option was not saved. This was due to the XAML binding being (unnecessarily) overriden from code using `bindTextBox`, which did not set `UpdateSourceTrigger`.